### PR TITLE
Make titles customizable

### DIFF
--- a/microsite/__main__.py
+++ b/microsite/__main__.py
@@ -26,7 +26,7 @@ DEFAULT_PROJECT_CONFIG = {
                 'rewrite_md_urls': True,
                 'stylesheet': 'microsite/render/styles/plain-white.css',
                 'stylesheet_target_name': 'style.css',
-                'template_dir': 'microsite/render/templates/',
+                'title': '',
             }
         },
     }

--- a/microsite/render/README.md
+++ b/microsite/render/README.md
@@ -19,6 +19,7 @@ The Markdown render engine can be configured with the following options:
 - `rewrite_md_urls`: When True, each HTML page is reviewed before being saved. Any links pointing to another project file using the `*.md` extension will have those extensions replaced with `*.html`. This is typically used in conjunction with `rewrite_md_extensions` to preserve the validity of links after rendering. You usually want this set to True, which is the default, although if you disable `rewrite_md_extensions` you may wish to disable this as well.
 - `stylesheet`: Path to the stylesheet to embed with every page. Defaults to the `plain-white.css` stylesheet included in this project.
 - `stylesheet_target_name`: Name to give the stylesheet file when it's copied into the output directory. This defaults to `style.css`, which is typically fine. Change this value if you have some other file in the root directory of your project called `style.css` which would otherwise be overwritten during rendering.   
+- `title` - The value to use as the `<title>` text for each page rendered.
 
 A completely default configuration for your project file looks like this:
 
@@ -32,6 +33,20 @@ rewrite_md_urls = true
 stylesheet = "microsite/render/styles/plain-white.css"
 stylesheet_target_name = "style.css"
 ```
+
+
+### Page Indexing
+
+One special option needs some extra attention: the `index` option. This is a table of metadata about your source files. You define indices by naming a config table after them. For example:
+
+```toml
+[render.engine.markdown.index."page2.md"]
+title = "Page 2!"
+```
+
+Each `index` entry has the following options:
+
+- `title` - Override the `<title>` text for this page.
 
 
 ### Jinja Templates

--- a/microsite/render/markdown.py
+++ b/microsite/render/markdown.py
@@ -135,7 +135,12 @@ class MarkdownRenderEngine(RenderEngine):
         j2_tpl = j2_env.get_template(_html_template)
         dots = '../' * (len(source_file.split('/')) - 1)
         relative_stylesheet = f'{dots}{self.config.stylesheet_target_name}'
-        page_html = j2_tpl.render(stylesheet=relative_stylesheet, title='TODO!', html=md_html)
+
+        # Get the index config
+        index = AttrDict(self.config.index.get(source_file, {}))
+        title = index.title if index.title else self.config.title
+
+        page_html = j2_tpl.render(stylesheet=relative_stylesheet, title=title, html=md_html)
 
         # Convert to a BS object so we can manipulate it before writing it back out
         page_html = BeautifulSoup(page_html, features='html.parser')

--- a/sample-project.toml
+++ b/sample-project.toml
@@ -12,3 +12,10 @@ rewrite_md_extensions = true
 rewrite_md_urls = true
 stylesheet = "microsite/render/styles/plain-white.css"
 stylesheet_target_name = "style.css"
+title = "Microsite Sample Site"
+
+[render.engine.markdown.index."page2.md"]
+title = "Microsite Sample Site Page 2"
+
+[render.engine.markdown.index."dir/page3.md"]
+title = "Microsite Sample Site Subdirectory Example"

--- a/sample-site/dir/page3.md
+++ b/sample-site/dir/page3.md
@@ -1,3 +1,5 @@
 # This Page
 
 Is in a nested directory!
+
+[Go back up](../index.md)


### PR DESCRIPTION
This creates an "index" option, which allows for setting arbitrary per-file metadata. We use this here to allow overriding of a default page title.