### PR TITLE
Fix a ton of pathing issues

### DIFF
--- a/microsite/path.py
+++ b/microsite/path.py
@@ -57,7 +57,7 @@ def validate_dir(dir: str) -> bool:
     :rtype: bool
     """
 
-    source = Path(dir).resolve()
+    source = Path(dir).expanduser().resolve()
     if not source.exists():
         raise ValueError(f'Source directory {source} does not exist.')
     if not source.is_dir():

--- a/microsite/publish/__init__.py
+++ b/microsite/publish/__init__.py
@@ -77,12 +77,12 @@ class PulumiPublishEngine(PublishEngine):
             self.temp_work_dir = None
 
         # Jinja environment for other functions to operate in
-        template_dir = Path('microsite/publish/static/pulumi/templates').resolve()
+        template_dir = Path('microsite/publish/static/pulumi/templates').expanduser().resolve()
         _j2_loader = jinja2.FileSystemLoader(searchpath=template_dir)
         self.pulumi_templates = jinja2.Environment(loader=_j2_loader)
 
         # Pulumi's operating environment
-        self.work_dir = Path(self.config.pulumi_work_dir).resolve()
+        self.work_dir = Path(self.config.pulumi_work_dir).expanduser().resolve()
         self.work_dir_str = str(self.work_dir)
         self.pulumi_environment = self.__build_pulumi_environment()
 
@@ -109,8 +109,14 @@ class PulumiPublishEngine(PublishEngine):
             with open(self.config.pulumi_access_token_file, 'r') as file:
                 env_vars['PULUMI_CONFIG_ACCESS_TOKEN'] = file.read().strip()
 
-        with open(self.config.pulumi_passphrase_file, 'r') as file:
-            env_vars['PULUMI_CONFIG_PASSPHRASE'] = file.read().strip()
+        if self.config.pulumi_passphrase_file:
+            self.config.pulumi_passphrase_file = (
+                Path(self.config.pulumi_passphrase_file).expanduser().resolve()
+            )
+            with self.config.pulumi_passphrase_file.open('r') as file:
+                env_vars['PULUMI_CONFIG_PASSPHRASE'] = file.read().strip()
+        else:
+            env_vars['PULUMI_CONFIG_PASSPHRASE'] = ''
 
         # Always suppress tb_pulumi's stack-level protection
         env_vars['TBPULUMI_DISABLE_PROTECTION'] = 'True'

--- a/microsite/publish/s3.py
+++ b/microsite/publish/s3.py
@@ -23,7 +23,7 @@ class TbPulumiS3Website(TBPulumiPublishEngine):
         ]
         template_dir = Path(
             'microsite/publish/static/pulumi/tb_pulumi/s3_website/templates'
-        ).resolve()
+        ).expanduser().resolve()
 
         # Jinja environment for other functions to operate in
         _j2_loader = jinja2.FileSystemLoader(searchpath=template_dir)
@@ -41,7 +41,7 @@ class TbPulumiS3Website(TBPulumiPublishEngine):
         """
 
         template = self.website_templates.get_template('config.stack.yaml.j2')
-        source_dir = str(Path(self.source_dir).resolve())
+        source_dir = str(Path(self.source_dir).expanduser().resolve())
         content = template.render(
             {
                 's3_bucket_name': self.config.publish_bucket,

--- a/microsite/pulumi.py
+++ b/microsite/pulumi.py
@@ -32,7 +32,7 @@ class PulumiProject:
         Ensures the Pulumi working directory exists.
         """
 
-        workdir = Path(self.workdir).resolve()
+        workdir = Path(self.workdir).expanduser().resolve()
         if workdir.exists:
             log.debug(
                 f'Working directory {str(workdir)} exists. '

--- a/microsite/render/markdown.py
+++ b/microsite/render/markdown.py
@@ -55,7 +55,10 @@ class MarkdownRenderEngine(RenderEngine):
                 'conflicts with a filename in the source content. '
                 'Specify an alternate stylesheet target name.'
             )
-        shutil.copy(self.config.stylesheet, f'{target_dir}/{self.config.stylesheet_target_name}')
+        shutil.copy(
+            self.config.stylesheet or 'microsite/render/styles/plain-white.css',
+            f'{target_dir}/{self.config.stylesheet_target_name}',
+        )
 
         rendered_paths = []
         for path in paths:

--- a/microsite/render/markdown.py
+++ b/microsite/render/markdown.py
@@ -16,7 +16,9 @@ class MarkdownRenderEngine(RenderEngine):
         super().__init__(name='markdown', config=config)
 
         # Convert template path string to proper Path
-        self.html_template = Path(self.config.html_template)
+        self.html_template = Path(
+            self.config.html_template or 'microsite/render/templates/markdown.html.j2'
+        )
 
         # Resolve any pathing complications like symlinks into "real" paths
         self.html_template = Path.resolve(self.html_template)


### PR DESCRIPTION
This ensures that anytime we read a file path out of the config, we expand the `~` character into the user's home directory. It also sets some default values where there were none before.