### PR TITLE
Fix various templating problems

### DIFF
--- a/microsite/__main__.py
+++ b/microsite/__main__.py
@@ -4,7 +4,6 @@ Main entrypoint to the microsite command line utility.
 
 import logging
 import tomllib
-import sys
 
 from argparse import ArgumentParser
 from copy import deepcopy
@@ -66,7 +65,7 @@ def parse_args() -> None:
         action='store_true',
     )
     subparsers = parser.add_subparsers(help='Runmode for the tool', dest='runmode')
-    render_parser = subparsers.add_parser(
+    _render_parser = subparsers.add_parser(
         'render', help='Run in render mode to convert content into web content'
     )
     publish_parser = subparsers.add_parser(

--- a/microsite/publish/__init__.py
+++ b/microsite/publish/__init__.py
@@ -78,9 +78,7 @@ class PulumiPublishEngine(PublishEngine):
 
         # Jinja environment for other functions to operate in
         _module_dir = '/'.join(__file__.split('/')[0:-1])
-        tpl_path_internal = Path(
-            f'{_module_dir}/static/pulumi/tb_pulumi/s3_website/templates'
-        ).expanduser().resolve()
+        tpl_path_internal = Path(f'{_module_dir}/static/pulumi/templates').expanduser().resolve()
         _j2_loader = jinja2.FileSystemLoader(searchpath=tpl_path_internal)
         self.pulumi_templates = jinja2.Environment(loader=_j2_loader)
 

--- a/microsite/publish/__init__.py
+++ b/microsite/publish/__init__.py
@@ -77,8 +77,11 @@ class PulumiPublishEngine(PublishEngine):
             self.temp_work_dir = None
 
         # Jinja environment for other functions to operate in
-        template_dir = Path('microsite/publish/static/pulumi/templates').expanduser().resolve()
-        _j2_loader = jinja2.FileSystemLoader(searchpath=template_dir)
+        _module_dir = '/'.join(__file__.split('/')[0:-1])
+        tpl_path_internal = Path(
+            f'{_module_dir}/static/pulumi/tb_pulumi/s3_website/templates'
+        ).expanduser().resolve()
+        _j2_loader = jinja2.FileSystemLoader(searchpath=tpl_path_internal)
         self.pulumi_templates = jinja2.Environment(loader=_j2_loader)
 
         # Pulumi's operating environment

--- a/microsite/publish/s3.py
+++ b/microsite/publish/s3.py
@@ -28,7 +28,6 @@ class TbPulumiS3Website(TBPulumiPublishEngine):
         tpl_path_internal = Path(
             f'{_module_dir}/static/pulumi/tb_pulumi/s3_website/templates'
         ).resolve()
-        log.info(f'DEBUG -- tpl_path_internal: {tpl_path_internal}')
 
         # Jinja environment for other functions to operate in
         _j2_loader = jinja2.FileSystemLoader(searchpath=tpl_path_internal)

--- a/microsite/publish/s3.py
+++ b/microsite/publish/s3.py
@@ -1,8 +1,11 @@
 import jinja2
+import logging
 
 from microsite.util import AttrDict
 from microsite.publish import TBPulumiPublishEngine
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 
 class TbPulumiS3Website(TBPulumiPublishEngine):
@@ -21,13 +24,15 @@ class TbPulumiS3Website(TBPulumiPublishEngine):
             'pulumi_aws>=6.65.0,<7',
             'tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@v0.0.14',
         ]
-        template_dir = Path(
-            'microsite/publish/static/pulumi/tb_pulumi/s3_website/templates'
-        ).expanduser().resolve()
+        _module_dir = '/'.join(__file__.split('/')[0:-1])
+        tpl_path_internal = Path(
+            f'{_module_dir}/static/pulumi/tb_pulumi/s3_website/templates'
+        ).resolve()
+        log.info(f'DEBUG -- tpl_path_internal: {tpl_path_internal}')
 
         # Jinja environment for other functions to operate in
-        _j2_loader = jinja2.FileSystemLoader(searchpath=template_dir)
-        self.website_templates = jinja2.Environment(loader=_j2_loader)
+        _j2_loader = jinja2.FileSystemLoader(searchpath=tpl_path_internal)
+        self.microsite_templates = jinja2.Environment(loader=_j2_loader)
 
         # These variables adjust according to user input
         self.filename_config_stack_yaml = f'config.{self.config.pulumi_stack_name}.yaml'
@@ -40,7 +45,7 @@ class TbPulumiS3Website(TBPulumiPublishEngine):
         Constructs the ``config.$stack.yaml`` file required by tb_pulumi.
         """
 
-        template = self.website_templates.get_template('config.stack.yaml.j2')
+        template = self.microsite_templates.get_template('config.stack.yaml.j2')
         source_dir = str(Path(self.source_dir).expanduser().resolve())
         content = template.render(
             {
@@ -57,13 +62,15 @@ class TbPulumiS3Website(TBPulumiPublishEngine):
         Constructs the __main__.py file that defines the build pattern.
         """
 
-        template = self.website_templates.get_template('__main__.py.j2')
-        content = template.render({
-            'acm_certificate_arn': self.config.acm_certificate_arn,
-            'domain': self.config.domain,
-            'route53_zone_id': self.config.route53_zone_id,
-            'subdomain': self.config.subdomain,
-        })
+        template = self.microsite_templates.get_template('__main__.py.j2')
+        content = template.render(
+            {
+                'acm_certificate_arn': self.config.acm_certificate_arn,
+                'domain': self.config.domain,
+                'route53_zone_id': self.config.route53_zone_id,
+                'subdomain': self.config.subdomain,
+            }
+        )
 
         with self.file_main_py.open('w') as file:
             file.write(content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,9 @@ dev = [
     "ruff>=0.12,<1.0",
     "Sphinx>=8.2.3,<9.0",
 ]
+
+[build-system]
+requires = [
+    "setuptools>=80.9.0,<81.0",
+    "setuptools-scm>=8.3.1,<9",
+]


### PR DESCRIPTION
Several problems pop up related to template paths if you try to use Microsite in another project's repo. This fixes things so the pathing is relative to the installation path of the module, not the content project directory.