### PR TITLE
Move index to all render engines, not just the Markdown one

### DIFF
--- a/microsite/__main__.py
+++ b/microsite/__main__.py
@@ -142,7 +142,8 @@ def main() -> None:
 
         render_engines = [
             RENDER_ENGINE_CLASS_MAP[engine](
-                config=AttrDict(project.render.engine[engine]), index=project.render.index
+                config=AttrDict(project.render.engine[engine]),
+                index=project.render.index if project.render.index else {},
             )
             for engine in project.render.engines
         ]

--- a/microsite/__main__.py
+++ b/microsite/__main__.py
@@ -141,7 +141,9 @@ def main() -> None:
         from microsite.render import render
 
         render_engines = [
-            RENDER_ENGINE_CLASS_MAP[engine](config=AttrDict(project.render.engine[engine]))
+            RENDER_ENGINE_CLASS_MAP[engine](
+                config=AttrDict(project.render.engine[engine]), index=project.render.index
+            )
             for engine in project.render.engines
         ]
 

--- a/microsite/render/__init__.py
+++ b/microsite/render/__init__.py
@@ -21,13 +21,21 @@ class RenderEngine(ABC, Engine):
     :param name: The name of the rendering engine.
     :type name: str
 
-    :param config: A dict containing operating parameters for this rendering engines.
+    :param config: A dict containing operating parameters for this rendering engine.
     :type config: dict
+
+    :param index: Dict where the keys are paths to source files and the values are dicts with
+        the following optional settings:
+
+        - ``tags``: List of terms relevant to the content of the page.
+        - ``title``: Used to override the ``<title>`` text for the page.
     """
 
-    def __init__(self, name: str, config: AttrDict):
+    def __init__(self, name: str, config: AttrDict, index: dict):
         super().__init__(name=name, config=config)
+        self.index = index
         log.debug(f'Created rendering engine {name} with options: {config}')
+        log.debug(f'Document index: {self.index}')
 
     @abstractclassmethod
     def render(self, source_dir: str, target_dir: str, paths: list[str]) -> list[str]:
@@ -43,9 +51,6 @@ class RenderEngine(ABC, Engine):
         :param paths: List of all paths in the source directory to be processed. Not every path in
             this list will be rendered.
         :type paths: list[str]
-
-        :return: List of paths this RenderEngine made alterations to.
-        :rtype: list[str]
         """
         pass
 

--- a/microsite/render/__init__.py
+++ b/microsite/render/__init__.py
@@ -31,7 +31,7 @@ class RenderEngine(ABC, Engine):
         - ``title``: Used to override the ``<title>`` text for the page.
     """
 
-    def __init__(self, name: str, config: AttrDict, index: dict):
+    def __init__(self, name: str, config: AttrDict, index: dict = {}):
         super().__init__(name=name, config=config)
         self.index = index
         log.debug(f'Created rendering engine {name} with options: {config}')

--- a/microsite/render/markdown.py
+++ b/microsite/render/markdown.py
@@ -12,8 +12,8 @@ log = logging.getLogger(__name__)
 
 
 class MarkdownRenderEngine(RenderEngine):
-    def __init__(self, config: AttrDict):
-        super().__init__(name='markdown', config=config)
+    def __init__(self, config: AttrDict, index: dict):
+        super().__init__(name='markdown', config=config, index=index)
 
         # Convert template path string to proper Path
         self.html_template = Path(
@@ -142,7 +142,7 @@ class MarkdownRenderEngine(RenderEngine):
         relative_stylesheet = f'{dots}{self.config.stylesheet_target_name}'
 
         # Get the index config
-        index = AttrDict(self.config.index.get(source_file, {}))
+        index = AttrDict(self.index.get(source_file, {}))
         title = index.title if index.title else self.config.title
 
         page_html = j2_tpl.render(stylesheet=relative_stylesheet, title=title, html=md_html)

--- a/microsite/render/markdown.py
+++ b/microsite/render/markdown.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 
 class MarkdownRenderEngine(RenderEngine):
-    def __init__(self, config: AttrDict, index: dict):
+    def __init__(self, config: AttrDict, index: dict = {}):
         super().__init__(name='markdown', config=config, index=index)
 
         # Convert template path string to proper Path

--- a/sample-project.toml
+++ b/sample-project.toml
@@ -14,10 +14,10 @@ stylesheet = "microsite/render/styles/plain-white.css"
 stylesheet_target_name = "style.css"
 title = "Microsite Sample Site"
 
-[render.engine.markdown.index."page2.md"]
+[render.index."page2.md"]
 title = "Microsite Sample Site Page 2"
 
-[render.engine.markdown.index."dir/page3.md"]
+[render.index."dir/page3.md"]
 title = "Microsite Sample Site Subdirectory Example"
 
 [publish]


### PR DESCRIPTION
Provide a default empty index as well.