### PR TITLE
Allow arbitary passing of template variables into Markdown renderer

### DIFF
--- a/microsite/render/markdown.py
+++ b/microsite/render/markdown.py
@@ -143,10 +143,11 @@ class MarkdownRenderEngine(RenderEngine):
 
         # Get the index config
         index = AttrDict(self.index.get(source_file, {}))
-        title = index.pop('title') if 'title' in index else self.config.title
+        title = index.title if index.title else self.config.title
+        additional_vars = {k: v for k, v in index.items() if k.startswith('md_')}
 
         page_html = j2_tpl.render(
-            stylesheet=relative_stylesheet, title=title, html=md_html, **index
+            stylesheet=relative_stylesheet, title=title, html=md_html, **additional_vars
         )
 
         # Convert to a BS object so we can manipulate it before writing it back out

--- a/microsite/render/markdown.py
+++ b/microsite/render/markdown.py
@@ -143,9 +143,11 @@ class MarkdownRenderEngine(RenderEngine):
 
         # Get the index config
         index = AttrDict(self.index.get(source_file, {}))
-        title = index.title if index.title else self.config.title
+        title = index.pop('title') if 'title' in index else self.config.title
 
-        page_html = j2_tpl.render(stylesheet=relative_stylesheet, title=title, html=md_html)
+        page_html = j2_tpl.render(
+            stylesheet=relative_stylesheet, title=title, html=md_html, **index
+        )
 
         # Convert to a BS object so we can manipulate it before writing it back out
         page_html = BeautifulSoup(page_html, features='html.parser')


### PR DESCRIPTION
Stick them in the index for your page and give them a `md_` prefix.